### PR TITLE
update auth data field name and values (requested by Adyen)

### DIFF
--- a/src/checkout/model_payment_request.go
+++ b/src/checkout/model_payment_request.go
@@ -114,20 +114,20 @@ type PaymentRequest struct {
 	// If set to true, you will only perform the [3D Secure 2 authentication](https://docs.adyen.com/checkout/3d-secure/other-3ds-flows/authentication-only), and not the payment authorisation.
 	ThreeDSAuthenticationOnly bool `json:"threeDSAuthenticationOnly,omitempty"`
 	// Set to true if the payment should be routed to a trusted MID.
-	TrustedShopper bool `json:"trustedShopper,omitempty"`
-    AuthenticationData *AuthenticationData `json:"authenticationData,omitempty"`
+	TrustedShopper              bool                         `json:"trustedShopper,omitempty"`
+	DelegatedAuthenticationData *DelegatedAuthenticationData `json:"delegatedAuthenticationData,omitempty"`
 }
 
-type AuthenticationData struct {
-    DelegatedAuthenticationRequested bool                 `json:"delegatedAuthenticationRequested"`
-    FirstAuthenticationFactor        AuthenticationFactor `json:"firstAuthenticationFactor,omitempty"`
-    SecondAuthenticationFactor       AuthenticationFactor `json:"secondAuthenticationFactor,omitempty"`
+type DelegatedAuthenticationData struct {
+	DelegatedAuthenticationRequested bool                 `json:"delegatedAuthenticationRequested"`
+	FirstAuthenticationFactor        AuthenticationFactor `json:"firstAuthenticationFactor,omitempty"`
+	SecondAuthenticationFactor       AuthenticationFactor `json:"secondAuthenticationFactor,omitempty"`
 }
 
 type AuthenticationFactor string
 
 const (
-    AuthenticationFactorPossessionOnly                       AuthenticationFactor = "PossesionOnly"
-    AuthenticationFactorUserVerificationBiometricFingerprint AuthenticationFactor = "UserVerificationBiometricFingerprint"
-    AuthenticationFactorUserVerificationPinOrPassword        AuthenticationFactor = "UserVerificationPinOrPassword"
+	AuthenticationFactorPossessionOnly                       AuthenticationFactor = "possessionOnly"
+	AuthenticationFactorUserVerificationBiometricFingerprint AuthenticationFactor = "userVerificationBiometricFingerprint"
+	AuthenticationFactorUserVerificationPinOrPassword        AuthenticationFactor = "userVerificationPinOrPassword"
 )


### PR DESCRIPTION
Adyen requested us to change the name of the field from authenticationData to delegatedAuthenticationData and the values:

1. Typo: possesion -> possession
2. small caps

The changes are available for both the /getToken endpoint and the /authorise endpoint, the new request object would look like this:

```
{
  "delegatedAuthenticationData": {
    "delegatedAuthenticationRequested": true,
    "firstAuthenticationFactor": "userVerificationBiometricFingerprint",
    "secondAuthenticationFactor": "possessionOnly"
  }
}
```

Ref: 
https://vippsas.atlassian.net/browse/TE-1797
https://vippsas.atlassian.net/browse/TCP-2314